### PR TITLE
Add more log messages to test.sh, running time detail to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ conda install -c bioconda mitos=2.0.8
 
 
 # Test run
-### Test-run mtGrasp to ensure all required dependencies are installed
+### Test-run mtGrasp to ensure all required dependencies are installed properly
+The test will take ~5-10min to complete.
+
 For conda users:
 ```
 mtgrasp.py -test

--- a/test/test.sh
+++ b/test/test.sh
@@ -4,12 +4,14 @@
 mitos_path=$1
 
 script_directory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo "Running test. Log messages can be found in test.log."
 mtgrasp.py -r1 ${script_directory}/SRR20078528_1M_subset_R1.fastq.gz -r2 ${script_directory}/SRR20078528_1M_subset_R2.fastq.gz -nsub -m 2 -o test_out -r ${script_directory}/NC_012920.1.fasta -mp ${mitos_path} &> test.log
 
 # check if final assembly fasta is generated
 file=$(find test_out/final_output/test_out_k91_kc3/ -name '*-assembly.fa' -print -quit)
 if [[ -n "$file" ]]; then
     echo "mtGrasp executed successfully. All required dependencies are installed."
+    echo "The output files can be found in the test_out directory. The final assembly file can be found at: test_out/final_output/test_out_k91_kc3/test_out_k91_kc3.final-mtgrasp_v1.1.0-assembly.fa"
 else
     echo "Error: mtGrasp could not run successfully due to missing dependencies. Please check the test.log file and make sure all required dependencies are installed before running the program."
 fi


### PR DESCRIPTION
* Added log messages to test.sh to give more detail, including a message to indicate that the command is running
  * So that the user doesn't think that the test is hanging
* Added approx. time for test completion to the README