### PR TITLE
Prepare for v1.1.2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ mtgrasp.py -r1 /path/to/read1.fq.gz -r2 /path/to/read2.fq.gz -o test_out -m 2 -r
 
 ***For users who don't have access to Conda***
 
-Make sure to specify the complete path to the "runmitos.py" script (can be found in the environment directory where you installed mitos
+If you've already added `runmitos.py` script from MITOS to your PATH, mtGrasp will find it automatically, so there's no need to specify -mp.
+
+If `runmitos.py` is not added to PATH, please make sure to specify the complete path to the "runmitos.py" script (can be found in the environment directory where you installed mitos)
 ```
 mtgrasp.py -r1 /path/to/read1.fq.gz -r2 /path/to/read2.fq.gz -o test_out -m 2 -r /path/to/mito_db/refs.fa -mp /path/to/mitos_env 
 ```

--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -4,7 +4,7 @@
 import argparse
 import subprocess
 import shlex
-mtgrasp_version = 'mtGrasp v1.1.1' # Make sure to edit the version for future releases
+mtgrasp_version = 'mtGrasp v1.1.2' # Make sure to edit the version for future releases
 # Required parameters 
 parser = argparse.ArgumentParser(description='The following arguments are required: -r1/--read1, -r2/--read2, -o/--out_dir, -m/--mt_gen, -r/--ref_path')
 parser.add_argument('-r1', '--read1', help='Forward read fastq.gz file [Required]')

--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -63,7 +63,21 @@ mitos_path=args.mitos_path
 test_run=args.test_run
 
 
-
+# check if 'runmitos.py' is in PATH
+output = subprocess.Popen(['which', 'runmitos.py'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+stdout, _ = output.communicate()
+path_output = stdout.decode().strip()
+if '/runmitos.py' in path_output:
+  mitos_path = path_output.replace('/runmitos.py','')
+else:
+  # check if conda is available
+  find_conda = subprocess.Popen(['conda', '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  _, stderr = find_conda.communicate()
+  if stderr:
+    print('mtGrasp is executed in a non-Conda environment. Please add the full path to runmitos.py to your $PATH.')
+    sys.exit()
+  else:
+    pass
 
 # get the directory of the mtgrasp.smk script
 string = subprocess.check_output(['which', 'mtgrasp.smk'])

--- a/mtgrasp.smk
+++ b/mtgrasp.smk
@@ -1,6 +1,6 @@
 # Snakemake file for mtGrasp pipeline
 # Make sure to edit the version for new releases
-mtgrasp_version = 'v1.1.1'
+mtgrasp_version = 'v1.1.2'
 
 
 import os.path

--- a/mtgrasp_standardize.py
+++ b/mtgrasp_standardize.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # Make sure to edit the version for new releases
-mtgrasp_version = 'v1.1.1'
+mtgrasp_version = 'v1.1.2'
 
 import argparse
 import sys

--- a/mtgrasp_summarize.py
+++ b/mtgrasp_summarize.py
@@ -3,7 +3,7 @@
 '''
 This script can be used to summarize mtGrasp assembly outputs by providing a text file containing the relative or complete path(s) to assembly output folder(s). 
 '''
-mtgrasp_version = 'v1.1.1' # Make sure to edit the version for future releases
+mtgrasp_version = 'v1.1.2' # Make sure to edit the version for future releases
 
 import argparse
 import os


### PR DESCRIPTION
Implemented a checkpoint to verify whether 'runmitos.py' exists in the user's PATH. If it's already included, there's no longer a need to specify "-mp".