### PR TITLE
Use multi-character strings for snakemake config parameters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
 
   - script: |
       source activate mtgrasp_ci
-      conda install --yes -c bioconda -c conda-forge python=3.10 mamba
+      conda install --yes -c bioconda -c conda-forge python mamba
       mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos>=2.1.7'
     displayName: Install dependencies
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
 
   - script: |
       source activate mtgrasp_ci
-      conda install --yes -c bioconda -c conda-forge python=3.10 mamba
+      conda install --yes -c bioconda -c conda-forge python mamba
       mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos>=2.1.7'
     displayName: Install dependencies
 

--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -119,16 +119,16 @@ if test_run:
     subprocess.run(shlex.split(f"{script_dir}/test/test.sh {mitos_path}"), check=True)
 elif dry_run:
     subprocess.run(shlex.split(f"snakemake -s {script_dir}/mtgrasp.smk -np --config r1={r1} r2={r2} out_dir={out_dir} "\
-                                f"mt_code={mt_gen} k={kmer} kc={kc} ref_path={ref_path} threads={threads} " \
-                                f"abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p={p}  sealer_k={sealer_k} " \
+                                f"mt_code={mt_gen} kmer={kmer} kc={kc} ref_path={ref_path} threads={threads} " \
+                                f"abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p_gapfill={p}  sealer_k={sealer_k} " \
                                 f"end_recov_sealer_fpr={end_recov_sealer_fpr} end_recov_p={end_recov_p} " \
                                 f"end_recov_sealer_k={end_recov_sealer_k} mismatch_allowed={mismatch_allowed} "\
                                 f"annotate='N/A' mitos_path={mitos_path} "),
                    check=True)
 elif unlock:
     subprocess.run(shlex.split(f"snakemake -s {script_dir}/mtgrasp.smk --unlock --config r1={r1} r2={r2} " \
-                                f"out_dir={out_dir} mt_code={mt_gen} k={kmer} kc={kc} ref_path={ref_path} " \
-                                f"threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p={p} " \
+                                f"out_dir={out_dir} mt_code={mt_gen} kmer={kmer} kc={kc} ref_path={ref_path} " \
+                                f"threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p_gapfill={p} " \
                                 f" sealer_k={sealer_k}  end_recov_sealer_fpr={end_recov_sealer_fpr} " \
                                 f"end_recov_p={end_recov_p} end_recov_sealer_k={end_recov_sealer_k} " \
                                 f"mismatch_allowed={mismatch_allowed} annotate='N/A' mitos_path={mitos_path} "),
@@ -138,8 +138,8 @@ elif nosubsample and annotate:
     print('Subsampling skipped')
 # Run mtgrasp.smk on the entire read dataset without subsampling
     subprocess.run(shlex.split(f"snakemake -s {script_dir}/mtgrasp.smk --cores {threads} -p -k --config r1={r1} " \
-                                f"r2={r2} out_dir={out_dir} mt_code={mt_gen} k={kmer} kc={kc} ref_path={ref_path} " \
-                                f"threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p={p} " \
+                                f"r2={r2} out_dir={out_dir} mt_code={mt_gen} kmer={kmer} kc={kc} ref_path={ref_path} " \
+                                f"threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p_gapfill={p} " \
                                 f" sealer_k={sealer_k}  end_recov_sealer_fpr={end_recov_sealer_fpr} " \
                                 f"end_recov_p={end_recov_p} end_recov_sealer_k={end_recov_sealer_k} " \
                                 f"mismatch_allowed={mismatch_allowed} annotate='Yes' mitos_path={mitos_path} "),
@@ -148,8 +148,8 @@ elif nosubsample and not annotate:
     print('Subsampling skipped')
 # Run mtgrasp.smk on the entire read dataset without subsampling
     subprocess.run(shlex.split(f"snakemake -s {script_dir}/mtgrasp.smk --cores {threads} -p -k --config r1={r1} " \
-                                f"r2={r2} out_dir={out_dir} mt_code={mt_gen} k={kmer} kc={kc} ref_path={ref_path} " \
-                                f" threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p={p} " \
+                                f"r2={r2} out_dir={out_dir} mt_code={mt_gen} kmer={kmer} kc={kc} ref_path={ref_path} " \
+                                f" threads={threads} abyss_fpr={abyss_fpr} sealer_fpr={sealer_fpr} p_gapfill={p} " \
                                 f" sealer_k={sealer_k}  end_recov_sealer_fpr={end_recov_sealer_fpr} " \
                                 f"end_recov_p={end_recov_p} end_recov_sealer_k={end_recov_sealer_k} " \
                                 f"mismatch_allowed={mismatch_allowed} annotate='No' mitos_path={mitos_path} "),

--- a/mtgrasp.smk
+++ b/mtgrasp.smk
@@ -22,7 +22,7 @@ else:
 # Start of the pipeline
 rule all:
      input:
-        expand(current_dir + "{library}/final_output/{library}_k{k}_kc{kc}/{library}_k{k}_kc{kc}.final-mtgrasp_%s-assembly.fa"%(mtgrasp_version), library = config["out_dir"], k = config["k"], kc = config["kc"])
+        expand(current_dir + "{library}/final_output/{library}_k{k}_kc{kc}/{library}_k{k}_kc{kc}.final-mtgrasp_%s-assembly.fa"%(mtgrasp_version), library = config["out_dir"], k = config["kmer"], kc = config["kc"])
 
 
 
@@ -235,7 +235,7 @@ rule pre_polishing:
         r2=config['r2'],
         sealer_fpr=config['sealer_fpr'],
         threads=config['threads'],
-        p=config['p'],
+        p=config['p_gapfill'],
         k=config['sealer_k'],
         ref_config = current_dir + "{library}/blast/k{k}_kc{kc}-ntjoin_ref_config.csv",
         sealer=current_dir + "{library}/prepolishing/k{k}_kc{kc}_sealer.log",


### PR DESCRIPTION
* For snakemake v8.17.0+, there is an outstanding issue where it will not correctly parse single-character config parameters
* To avoid errors, change single character config parameters in `mtgrasp.smk` to multi-character strings
  * This is under the hood, and does not change the invocation of mtGrasp for users
