### PR TITLE
Fix BLAST DB location

### DIFF
--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -11,11 +11,11 @@ import sys
 MTGRASP_VERSION = 'mtGrasp v1.1.7'
 
 parser = argparse.ArgumentParser(description='mtGrasp: de novo assembly of reference-grade animal mitochondrial genomes')
-parser.add_argument('-r1', '--read1', help='Forward read fastq.gz file [Required]')
-parser.add_argument('-r2', '--read2', help='Reverse read fastq.gz file [Required]')
+parser.add_argument('-r1', '--read1', help='Full path to forward read fastq.gz file [Required]')
+parser.add_argument('-r2', '--read2', help='Full path to reverse read fastq.gz file [Required]')
 parser.add_argument('-o', '--out_dir', help='Output directory [Required]')
 parser.add_argument('-m', '--mt_gen', help='Mitochondrial genetic code [Required]')
-parser.add_argument('-r', '--ref_path', help='Path to the reference fasta file [Required]')
+parser.add_argument('-r', '--ref_path', help='Full path to the reference fasta file [Required]')
 
 parser.add_argument('-t', '--threads', help='Number of threads [8]', default = 8, type=int)
 parser.add_argument('-k', '--kmer', help='k-mer size used in ABySS de novo assembly [91]', default = 91, type=int)

--- a/mtgrasp.smk
+++ b/mtgrasp.smk
@@ -22,7 +22,7 @@ else:
 # Start of the pipeline
 rule all:
      input:
-        expand(current_dir + "{library}/final_output/{library}_k{k}_kc{kc}/{library}_k{k}_kc{kc}.final-mtgrasp_%s-assembly.fa"%(mtgrasp_version), library = config["out_dir"], k = config["kmer"], kc = config["kc"])
+        expand(current_dir + "{library}/final_output/{library}_k{k}_kc{kc}/{library}_k{k}_kc{kc}.final-mtgrasp_{version}-assembly.fa", library = config["out_dir"], k = config["kmer"], kc = config["kc"], version=mtgrasp_version)
 
 
 

--- a/mtgrasp.smk
+++ b/mtgrasp.smk
@@ -179,11 +179,11 @@ rule blast:
          db_name = os.path.splitext(os.path.basename(params.ref_fasta))[0]
 
          # check if a blast database exists
-         if not os.path.exists(f'{script_dir}/blast_db/{db_name}'):
-            shell("mkdir -p {script_dir}/blast_db/{db_name} && cd {script_dir}/blast_db/{db_name} && makeblastdb -in {params.ref_fasta} -dbtype nucl -out {db_name}")
-            shell("export BLASTDB={script_dir}/blast_db/{db_name} && mtgrasp_blast_best-hit.py {input} {db_name} > {output}")
+         if not os.path.exists(f'{library}/blast_db/{db_name}'):
+            shell("mkdir -p {library}/blast_db/{db_name} && cd {library}/blast_db/{db_name} && makeblastdb -in {params.ref_fasta} -dbtype nucl -out {db_name}")
+            shell("export BLASTDB={library}/blast_db/{db_name} && mtgrasp_blast_best-hit.py {input} {db_name} > {output}")
          else:
-            shell("export BLASTDB={script_dir}/blast_db/{db_name} && mtgrasp_blast_best-hit.py {input} {db_name} > {output}")
+            shell("export BLASTDB={library}/blast_db/{db_name} && mtgrasp_blast_best-hit.py {input} {db_name} > {output}")
          check_blast_tsv(f'{output}')
          
 rule create_lists:


### PR DESCRIPTION
* The BLAST database was created in a directory relative to the script directory
  * However, this creates problems when using docker images, as the location where scripts are installed is read-only
  * To solve this, create the BLAST db in the output folder of the working directory
* Make it explicit in the help page that full paths are required for reads, reference file 