### PR TITLE
Fix for mitos v2.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ The test will take ~5-10min to complete.
 mtgrasp.py -test
 ```
 
-If `runmitos.py` is not available on your PATH:
+If `runmitos.py` or `runmitos` is not available on your PATH:
 ```
 mtgrasp.py -test -mp /path/to/mitos_install_dir
 ```
-Note: `/path/to/mitos_install_dir` is the location where the main MITOS script `runmitos.py` is stored
+Note: `/path/to/mitos_install_dir` is the location where the main MITOS script `runmitos.py` or `runmitos` is stored
 # Running mtGrasp <a name=usage></a>
 
 ### Required Parameters 
@@ -141,7 +141,7 @@ However, if such sequences are unavailable, you can move up the taxonomic hierar
 
 `-d` or `--delete`: Delete intermediate subdirectories/files once mtGrasp finishes [False]
 
-`-mp` or `--mitos_path`: Complete path to `runmitos.py` (e.g., `/home/user/path/to/mitos/bin`), this is required if `runmitos.py` is not found on your `PATH` [None]
+`-mp` or `--mitos_path`: Complete path to `runmitos.py/runmitos` (e.g., `/home/user/path/to/mitos/bin`), this is required if `runmitos.py` or `runmitos` is not found on your `PATH` [None]
 
 `-test` or `--test_run`:Test run mtGrasp to ensure all required dependencies are installed [False]
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
   - script: |
       source activate mtgrasp_ci
       conda install --yes -c bioconda -c conda-forge python mamba
-      mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos=2.1.9' python=3.12
+      mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos>=2.1.10' python=3.12
     displayName: Install dependencies
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
 
   - script: |
       source activate mtgrasp_ci
-      mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos>=2.1.7' python=3.12
+      mamba install --yes -c conda-forge -c bioconda snakemake 'blast>=2.9.0' biopython seqtk abyss ntjoin bwa samtools pilon ntcard 'mitos=2.1.9' python=3.12
     displayName: Install dependencies
 
   - script: |

--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -7,6 +7,7 @@ import argparse
 import subprocess
 import shlex
 import sys
+import re
 
 MTGRASP_VERSION = 'mtGrasp v1.1.9'
 
@@ -51,7 +52,7 @@ parser.add_argument('-a', '--abyss_fpr', help='False positive rate for the Bloom
 parser.add_argument('-s', '--sealer_fpr',
                     help='False positive rate for the Bloom filter used by Sealer during gap filling [0.01]',
                     default = 0.01, type=float)
-parser.add_argument('-mp', '--mitos_path', help='Complete path to runmitos.py', default = None)
+parser.add_argument('-mp', '--mitos_path', help='Complete path to runmitos.py/runmitos', default = None)
 parser.add_argument('-an', '--annotate', help='Run gene annotation on the final assembly output [False]',
                     action='store_true')
 parser.add_argument('-d', '--delete',
@@ -105,6 +106,8 @@ if not args.mitos_path:
     path_output = stdout.decode().strip()
     if '/runmitos.py' in path_output:
         mitos_path = path_output.replace('/runmitos.py','')
+    elif mitos_match := re.search(r'^(\S+)\/runmitos$', path_output):
+        mitos_path = mitos_match.group(1)
     else:
         print("Please ensure runmitos.py is available on your PATH or specify the path using -mp")
         sys.exit(1)

--- a/mtgrasp.py
+++ b/mtgrasp.py
@@ -6,8 +6,9 @@ mtGrasp: de novo assembly of reference-grade animal mitochondrial genomes
 import argparse
 import subprocess
 import shlex
+import shutil
 import sys
-import re
+import os
 
 MTGRASP_VERSION = 'mtGrasp v1.1.9'
 
@@ -101,15 +102,11 @@ if not test_run and (not r1 or not r2 or not out_dir or not mt_gen or not ref_pa
 
 # If the mitos path isn't supplied, check if 'runmitos.py' is in PATH
 if not args.mitos_path:
-    output = subprocess.Popen(['which', 'runmitos.py'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, _ = output.communicate()
-    path_output = stdout.decode().strip()
-    if '/runmitos.py' in path_output:
-        mitos_path = path_output.replace('/runmitos.py','')
-    elif mitos_match := re.search(r'^(\S+)\/runmitos$', path_output):
-        mitos_path = mitos_match.group(1)
+    mitos_exec = shutil.which('runmitos.py') or shutil.which('runmitos')
+    if mitos_exec:
+        mitos_path = os.path.dirname(mitos_exec)
     else:
-        print("Please ensure runmitos.py is available on your PATH or specify the path using -mp")
+        print("Please ensure runmitos.py or runmitos is available on your PATH or specify the path using -mp")
         sys.exit(1)
 
 

--- a/mtgrasp_standardize.py
+++ b/mtgrasp_standardize.py
@@ -17,7 +17,7 @@ parser.add_argument('-o', '--output', help='Output directory', required=True)
 parser.add_argument('-p', '--prefix', help='Prefix for the output file', default='mtgrasp_standardized')
 parser.add_argument('-c', '--gencode', help='Mitochondrial genetic code used for gene annotation', required=True)
 parser.add_argument('-a', '--annotate', help='Run gene annotation on the final assembly output [False]', action='store_true')
-parser.add_argument('-mp', '--mitos_path', help='Complete path to runmitos.py', default = None)
+parser.add_argument('-mp', '--mitos_path', help='Complete path to runmitos.py/runmitos', default = None)
 
 args = parser.parse_args()
 file = args.input
@@ -158,8 +158,13 @@ def find_conda_env(env_name):
         print(f"Conda environment {env_name} not found.")
         sys.exit(1)
 
-
-        
+def get_full_mitos_path(mitos_path):
+    """Returns the full path to mitos. As of v2.1.10, the executable was renamed to runmitos."""
+    if os.path.exists(f"{mitos_path}/runmitos.py"):
+        return f"{mitos_path}/runmitos.py"
+    if os.path.exists(f"{mitos_path}/runmitos"):
+        return f"{mitos_path}/runmitos"
+    return None
 
 # This function runs MitoS annotation
 def run_mitos(env_name, file, code, dir, script_dir, mitos_path):
@@ -172,15 +177,14 @@ def run_mitos(env_name, file, code, dir, script_dir, mitos_path):
        return output
     # Run mitos independently without conda
     else:
-      if os.path.exists(f"{mitos_path}/runmitos.py"):
-
+      if full_path_to_mitos := get_full_mitos_path(mitos_path):
         # Add mitos_path to PATH
         new_path = mitos_path
         current_path = os.environ.get('PATH', '')
         new_path_value = f'{new_path}:{current_path}'
         os.environ['PATH'] = new_path_value
 
-        cmd = f"{mitos_path}/runmitos.py -i {file} --noplots  -c {code} -o {dir} --linear --refdir {script_dir}/data/refseqs_mitos -r refseq81m"
+        cmd = f"{full_path_to_mitos} -i {file} --noplots  -c {code} -o {dir} --linear --refdir {script_dir}/data/refseqs_mitos -r refseq81m"
         process = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE)
         output = process.communicate()[0].decode("utf-8").strip()
         return output


### PR DESCRIPTION
- In the conda recipe for mitos v2.1.10, the executable is named `runmitos` instead of `runmitos.py`
- To ensure compatibility, we now will look for either executable name in mtGrasp